### PR TITLE
Restrict BIT/RES/SET op1 to legal values

### DIFF
--- a/src/asmz80.c
+++ b/src/asmz80.c
@@ -1444,6 +1444,7 @@ int Z80_DoCPULabelOp(int typ, int parm, char *labl)
         case o_Bit:
             oldLine = linePtr;
             reg1 = Eval();                  // get bit number
+            if (reg1 > 7 || reg1 < 0) { IllegalOperand(); break; }
             token = GetWord(word);          // attempt to get comma
             // if end of line and SET opcode
             if (token == 0 && parm == 0xC0)


### PR DESCRIPTION
As there is currently no restriction on the value of BIT/SET/RES op1, this results in, for example: 'res 8,e' being assembled to CBC3 (set 0,e), rather than throwing an error.

This patch restricts op1 to legal values (0-7) and throws an 'Illegal operand' error otherwise.